### PR TITLE
Use more descriptive service names

### DIFF
--- a/docker-compose.typesense.yaml
+++ b/docker-compose.typesense.yaml
@@ -1,7 +1,7 @@
 #ddev-generated
 services:
-  server:
-    container_name: ddev-${DDEV_SITENAME}-server
+  typesense:
+    container_name: ddev-${DDEV_SITENAME}-typesense
     image: typesense/typesense:28.0
     command: '--data-dir /data --enable-cors'
     networks: [default, ddev_default]
@@ -25,9 +25,9 @@ services:
   # access the Typesense service at http://typesense:8108 or https://typesense:8109
   web:
     links:
-      - server:typesense
-  admin:
-    container_name: ddev-${DDEV_SITENAME}-admin
+      - typesense:typesense
+  typesensedashboard:
+    container_name: ddev-${DDEV_SITENAME}-typesensedashboard
     image: ghcr.io/bfritscher/typesense-dashboard:latest
     restart: always
     labels:


### PR DESCRIPTION
The service names are currently `server` and `admin` which are very generic and might conflict with custom services that might be defined in a project.

Let's rename them to `typesense` and `typesensedashboard` so it is more easy to see what these services are for.

Note that I initially wanted to use the name `typesense-dashboard` but the dashboard gives 504 errors if there is a dash in the service name. I wasn't able to figure out why this would affect the container.